### PR TITLE
Issue_7 Use principal's id to set the owner field. Also added unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /build/
 /target/
+**/.idea
+**/*iml

--- a/pom.xml
+++ b/pom.xml
@@ -96,16 +96,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.20.1</version>
-        <configuration>
-          <includes>
-            <include>**/ResourceManagerTestSuite.class</include>
-          </includes>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>

--- a/src/main/java/gov/bnl/olog/LogResource.java
+++ b/src/main/java/gov/bnl/olog/LogResource.java
@@ -8,15 +8,19 @@ package gov.bnl.olog;
 import static gov.bnl.olog.OlogResourceDescriptors.LOG_RESOURCE_URI;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -71,11 +75,14 @@ public class LogResource
                     return resource;
                 } catch (IOException e)
                 {
-                    e.printStackTrace();
+                    Logger.getLogger(LogResource.class.getName()).log(Level.WARNING,
+                            String.format("Unable to retrieve attachment %s for log id %s", attachmentName, logId),
+                            e);
                 }
             } else
             {
-                // Throw exception, either attachment not found or more than one found
+                Logger.getLogger(LogResource.class.getName()).log(Level.WARNING,
+                        String.format("Found %d attachments named %s for log id %s", attachments.size(), attachmentName, logId));
             }
         }
         return null;
@@ -92,7 +99,9 @@ public class LogResource
      * @return
      */
     @PutMapping()
-    public Log createLog(@RequestBody Log log) {
+    public Log createLog(@RequestBody Log log,
+                         @AuthenticationPrincipal Principal principal) {
+        log.setOwner(principal.getName());
         return logRepository.save(log);
     }
 

--- a/src/main/java/gov/bnl/olog/LogbooksResource.java
+++ b/src/main/java/gov/bnl/olog/LogbooksResource.java
@@ -7,10 +7,12 @@ package gov.bnl.olog;
 
 import static gov.bnl.olog.OlogResourceDescriptors.LOGBOOK_RESOURCE_URI;
 
+import java.security.Principal;
 import java.util.List;
 import java.util.logging.Logger;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -51,9 +53,12 @@ public class LogbooksResource {
     }
 
     @PutMapping("/{logbookName}")
-    public Logbook createLogbook(@PathVariable String logbookName, @RequestBody final Logbook logbook) {
+    public Logbook createLogbook(@PathVariable String logbookName,
+                                 @RequestBody final Logbook logbook,
+                                 @AuthenticationPrincipal Principal principal) {
         // TODO Check permissions
         // TODO Validate
+        logbook.setOwner(principal.getName());
         return logbookRepository.save(logbook);
     }
 

--- a/src/main/java/gov/bnl/olog/MongoConfig.java
+++ b/src/main/java/gov/bnl/olog/MongoConfig.java
@@ -6,6 +6,7 @@ import java.util.logging.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
 import org.springframework.data.mongodb.gridfs.GridFsTemplate;
@@ -14,6 +15,7 @@ import com.mongodb.MongoClient;
 
 @Configuration
 @PropertySource("classpath:application.properties")
+@Profile({ "production" })
 public class MongoConfig extends AbstractMongoConfiguration
 {
     private static final Logger log = Logger.getLogger(MongoClient.class.getName());

--- a/src/main/java/gov/bnl/olog/PropertiesResource.java
+++ b/src/main/java/gov/bnl/olog/PropertiesResource.java
@@ -8,10 +8,12 @@ package gov.bnl.olog;
 import static gov.bnl.olog.OlogResourceDescriptors.PROPERTY_RESOURCE_URI;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.List;
 import java.util.logging.Logger;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -58,10 +60,13 @@ public class PropertiesResource {
     }
 
     @PutMapping("/{propertyName}")
-    public Property createProperty(@PathVariable String propertyName, @RequestBody final Property property) {
+    public Property createProperty(@PathVariable String propertyName,
+                                   @RequestBody final Property property,
+                                   @AuthenticationPrincipal Principal principal) {
         // TODO Check permissions
         // TODO Validate
         // TODO Create a property
+        property.setOwner(principal.getName());
         return propertyRepository.save(property);
     }
 

--- a/src/test/java/gov/bnl/olog/LogResourceTest.java
+++ b/src/test/java/gov/bnl/olog/LogResourceTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import gov.bnl.olog.entity.Level;
+import gov.bnl.olog.entity.Log;
+import gov.bnl.olog.entity.Log.LogBuilder;
+import gov.bnl.olog.entity.Logbook;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests {@link gov.bnl.olog.entity.Log} resource endpoints. The authentication scheme used is the
+ * hard coded user/userPass credentials. The {@link LogRepository} is mocked.
+ */
+@RunWith(SpringRunner.class)
+@ContextHierarchy({@ContextConfiguration(classes = {ResourcesTestConfig.class})})
+@WebMvcTest(LogbookResourceTest.class)
+@TestPropertySource(locations = "classpath:no_ldap_test_application.properties")
+@ActiveProfiles({"test"})
+public class LogResourceTest extends ResourcesTestBase {
+
+    @Autowired
+    private LogRepository logRepository;
+
+    private Log log1;
+    private Log log2;
+
+    private Logbook logbook1;
+    private Logbook logbook2;
+
+    private Instant now = Instant.now();
+
+    @Before
+    public void init() {
+        logbook1 = new Logbook("name1", "user");
+        logbook2 = new Logbook("name2", "user");
+
+        log1 = LogBuilder.createLog()
+                .id(1L)
+                .owner("owner")
+                .withLogbooks(Set.of(logbook1, logbook2))
+                .description("description1")
+                .createDate(now)
+                .level(Level.Urgent)
+                .build();
+
+        log2 = LogBuilder.createLog()
+                .id(2L)
+                .owner("user")
+                .withLogbooks(Set.of(logbook1, logbook2))
+                .description("description2")
+                .createDate(now)
+                .level(Level.Urgent)
+                .build();
+
+    }
+
+    @Test
+    public void testGetLogById() throws Exception {
+        when(logRepository.findById("1")).thenAnswer(invocationOnMock -> Optional.of(log1));
+
+        MockHttpServletRequestBuilder request = get("/" + OlogResourceDescriptors.LOG_RESOURCE_URI + "/1");
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+        Log log = objectMapper.readValue(result.getResponse().getContentAsString(), Log.class);
+        assertEquals("description1", log.getDescription());
+        verify(logRepository, times(1)).findById("1");
+        reset(logRepository);
+    }
+
+    @Test
+    public void testFindLogs() throws Exception {
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.put("a", Arrays.asList("b"));
+
+        when(logRepository.search(map)).thenAnswer(invocationOnMock -> Arrays.asList(log1, log2));
+
+        MockHttpServletRequestBuilder request = get("/" + OlogResourceDescriptors.LOG_RESOURCE_URI)
+                .params(map)
+                .contentType(JSON);
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+
+        Iterable<Log> logs = objectMapper.readValue(result.getResponse().getContentAsString(),
+                new TypeReference<Iterable<Log>>() {
+                });
+        assertEquals(Long.valueOf(1L), logs.iterator().next().getId());
+        verify(logRepository, times(1)).search(map);
+        reset(logRepository);
+    }
+
+    @Test
+    public void testCreateLogUnauthorized() throws Exception {
+        MockHttpServletRequestBuilder request = put("/" + OlogResourceDescriptors.LOG_RESOURCE_URI)
+                .content(objectMapper.writeValueAsString(log1))
+                .contentType(JSON);
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testCreateLog() throws Exception {
+        Log log = LogBuilder.createLog()
+                .id(1L)
+                .owner("user")
+                .withLogbooks(Set.of(logbook1, logbook2))
+                .description("description1")
+                .createDate(now)
+                .level(Level.Urgent)
+                .build();
+
+        when(logRepository.save(argThat(new LogMatcher(log)))).thenReturn(log);
+        MockHttpServletRequestBuilder request = put("/" + OlogResourceDescriptors.LOG_RESOURCE_URI)
+                .content(objectMapper.writeValueAsString(log1))
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON);
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk()).andReturn();
+
+        Log savedLog = objectMapper.readValue(result.getResponse().getContentAsString(), Log.class);
+        assertEquals(Long.valueOf(1L), savedLog.getId());
+        verify(logRepository, times(1)).save(argThat(new LogMatcher(log)));
+        reset(logRepository);
+    }
+
+    /**
+     * Tests only endpoint URL.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetAttachment() throws Exception {
+        MockHttpServletRequestBuilder request = get("/" + OlogResourceDescriptors.LOG_RESOURCE_URI
+                + "/attachments/1/attachmentName");
+        mockMvc.perform(request).andExpect(status().isOk());
+    }
+
+    @Test
+    public void testCreateAttachmentUnauthroized() throws Exception {
+        MockHttpServletRequestBuilder request = put("/" + OlogResourceDescriptors.LOG_RESOURCE_URI
+                + "/attachments/1");
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    /**
+     * Test only endpoint URI
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCreateAttachment() throws Exception {
+        when(logRepository.findById("1")).thenReturn(Optional.of(log1));
+        MockMultipartFile file =
+                new MockMultipartFile("file", "filename.txt", "text/plain", "some xml".getBytes());
+        MockMultipartFile filename =
+                new MockMultipartFile("filename", "filename.txt", "text/plain", "some xml".getBytes());
+        MockMultipartFile fileMetadataDescription =
+                new MockMultipartFile("fileMetadataDescription", "filename.txt", "text/plain", "some xml".getBytes());
+        mockMvc.perform(MockMvcRequestBuilders.multipart("/" + OlogResourceDescriptors.LOG_RESOURCE_URI + "/attachments/1")
+                .file(file)
+                .file(filename)
+                .file(fileMetadataDescription)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION))
+                .andExpect(status().is(200));
+        reset(logRepository);
+    }
+
+
+    /**
+     * A matcher used to work around issues with {@link Log#equals(Object)} when using the mocks.
+     */
+    private class LogMatcher implements ArgumentMatcher<Log> {
+        private final Log expected;
+
+        public LogMatcher(Log expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        public boolean matches(Log obj) {
+            if (!(obj instanceof Log)) {
+                return false;
+            }
+            Log actual = (Log) obj;
+
+            boolean match = actual.getId() == expected.getId()
+                    && actual.getDescription().equals(expected.getDescription());
+
+            return match;
+        }
+    }
+}

--- a/src/test/java/gov/bnl/olog/LogbookResourceTest.java
+++ b/src/test/java/gov/bnl/olog/LogbookResourceTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package gov.bnl.olog;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import gov.bnl.olog.entity.Logbook;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests {@link Logbook} resource endpoints. The authentication scheme used is the
+ * hard coded user/userPass credentials. The {@link LogbookRepository} is mocked.
+ */
+@RunWith(SpringRunner.class)
+@ContextHierarchy({@ContextConfiguration(classes = {ResourcesTestConfig.class})})
+@WebMvcTest(LogbookResourceTest.class)
+@TestPropertySource(locations = "classpath:no_ldap_test_application.properties")
+@ActiveProfiles({"test"})
+public class LogbookResourceTest extends ResourcesTestBase{
+
+    @Autowired
+    private LogbookRepository logbookRepository;
+
+    private Logbook logbook1;
+    private Logbook logbook2;
+
+    @Before
+    public void init() {
+        logbook1 = new Logbook("name1", "user");
+        logbook2 = new Logbook("name2", "user");
+    }
+
+    @Test
+    public void testFindAll() throws Exception {
+        when(logbookRepository.findAll()).thenReturn(Arrays.asList(logbook1, logbook2));
+
+        MockHttpServletRequestBuilder request = get("/" + OlogResourceDescriptors.LOGBOOK_RESOURCE_URI);
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+        Iterable<Logbook> logbooks = objectMapper.readValue(result.getResponse().getContentAsString(),
+                new TypeReference<Iterable<Logbook>>() {
+                });
+        assertEquals("name1", logbooks.iterator().next().getName());
+        verify(logbookRepository, times(1)).findAll();
+        reset(logbookRepository);
+    }
+
+    @Test
+    public void testFindAllNoLogbooks() throws Exception {
+        when(logbookRepository.findAll()).thenReturn(new ArrayList<>());
+
+        MockHttpServletRequestBuilder request = get("/" + OlogResourceDescriptors.LOGBOOK_RESOURCE_URI);
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+        Iterable<Logbook> logbooks = objectMapper.readValue(result.getResponse().getContentAsString(),
+                new TypeReference<Iterable<Logbook>>() {
+                });
+        assertFalse(logbooks.iterator().hasNext());
+        verify(logbookRepository, times(1)).findAll();
+        reset(logbookRepository);
+    }
+
+    @Test
+    public void testFindLogbookByName() throws Exception {
+        when(logbookRepository.findById("name1")).thenReturn(Optional.of(logbook1));
+
+        MockHttpServletRequestBuilder request = get("/" +
+                OlogResourceDescriptors.LOGBOOK_RESOURCE_URI +
+                "/name1");
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+        Logbook logbook = objectMapper.readValue(result.getResponse().getContentAsString(),
+                Logbook.class);
+        assertEquals("name1", logbook.getName());
+        verify(logbookRepository, times(1)).findById("name1");
+        reset(logbookRepository);
+    }
+
+    @Test
+    public void testCreateLogbookUnauthorized() throws Exception {
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LOGBOOK_RESOURCE_URI +
+                "/name1")
+                .content(objectMapper.writeValueAsString(logbook1))
+                .contentType(JSON);
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testCreateLogbook() throws Exception {
+        Logbook logbookWithWrongOwnerName = new Logbook("name1", "owner1");
+        when(logbookRepository.save(logbook1)).thenReturn(logbook1);
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LOGBOOK_RESOURCE_URI +
+                "/name1")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .content(objectMapper.writeValueAsString(logbookWithWrongOwnerName))
+                .contentType(JSON);
+        mockMvc.perform(request).andExpect(status().isOk()).andReturn();
+        // Verify that the log repository mock has been called with the owner field set to "user", and not "owner1"
+        verify(logbookRepository, times(1)).save(logbook1);
+        reset(logbookRepository);
+    }
+
+    @Test
+    public void testUpdateLogbooksUnauthorized() throws Exception {
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LOGBOOK_RESOURCE_URI)
+                .content(objectMapper.writeValueAsString(new ArrayList<>()))
+                .contentType(JSON);
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testUpdateLogbooks() throws Exception {
+        List<Logbook> logbooks = Arrays.asList(logbook1, logbook2);
+        when(logbookRepository.saveAll(logbooks)).thenReturn(logbooks);
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.LOGBOOK_RESOURCE_URI)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .content(objectMapper.writeValueAsString(logbooks))
+                .contentType(JSON);
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk()).andReturn();
+        logbooks = objectMapper.readValue(result.getResponse().getContentAsString(),
+                new TypeReference<Iterable<Logbook>>() {
+                });
+        assertEquals("name1", logbooks.iterator().next().getName());
+        verify(logbookRepository, times(1)).saveAll(logbooks);
+        reset(logbookRepository);
+    }
+
+    @Test
+    public void testDeleteUnauthorized() throws Exception{
+        MockHttpServletRequestBuilder request = delete("/" +
+                OlogResourceDescriptors.LOGBOOK_RESOURCE_URI +
+                "/name1");
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testDelete() throws Exception{
+        MockHttpServletRequestBuilder request = delete("/" +
+                OlogResourceDescriptors.LOGBOOK_RESOURCE_URI +
+                "/name1")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION);
+        mockMvc.perform(request).andExpect(status().isOk());
+        verify(logbookRepository, times(1)).deleteById("name1");
+        reset(logbookRepository);
+    }
+}

--- a/src/test/java/gov/bnl/olog/PropertiesResourceTest.java
+++ b/src/test/java/gov/bnl/olog/PropertiesResourceTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import gov.bnl.olog.entity.Property;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@ContextHierarchy({@ContextConfiguration(classes = {ResourcesTestConfig.class})})
+@WebMvcTest(LogbookResourceTest.class)
+@TestPropertySource(locations = "classpath:no_ldap_test_application.properties")
+@ActiveProfiles({"test"})
+public class PropertiesResourceTest extends ResourcesTestBase {
+
+    @Autowired
+    private PropertyRepository propertyRepository;
+
+    private Property property1;
+    private Property property2;
+
+    @Before
+    public void init() {
+        property1 = new Property("property1");
+        property2 = new Property("property2");
+    }
+
+    @Test
+    public void testFindAll() throws Exception {
+        when(propertyRepository.findAll()).thenReturn(Arrays.asList(property1, property2));
+
+        MockHttpServletRequestBuilder request = get("/" + OlogResourceDescriptors.PROPERTY_RESOURCE_URI);
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+        Iterable<Property> properties = objectMapper.readValue(result.getResponse().getContentAsString(), new TypeReference<Iterable<Property>>() {
+        });
+        assertEquals("property1", properties.iterator().next().getName());
+        verify(propertyRepository, times(1)).findAll();
+        reset(propertyRepository);
+    }
+
+    @Test
+    public void testFindById() throws Exception {
+        when(propertyRepository.findById("property1")).thenReturn(Optional.of(property1));
+        MockHttpServletRequestBuilder request = get("/" +
+                OlogResourceDescriptors.PROPERTY_RESOURCE_URI +
+                "/property1");
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk())
+                .andReturn();
+        Property property = objectMapper.readValue(result.getResponse().getContentAsString(), Property.class);
+        assertEquals("property1", property.getName());
+        verify(propertyRepository, times(1)).findById("property1");
+        reset(propertyRepository);
+    }
+
+    @Test
+    public void testCreatePropertyUnauthorized() throws Exception {
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.PROPERTY_RESOURCE_URI +
+                "/property1");
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testCreateProperty() throws Exception {
+
+        Property property = new Property("property1");
+        property.setOwner("user");
+
+        when(propertyRepository.save(argThat(new PropertyMatcher(property)))).thenReturn(property);
+
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.PROPERTY_RESOURCE_URI +
+                "/property1")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON)
+                .content(objectMapper.writeValueAsString(property1));
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk()).andReturn();
+        objectMapper.readValue(result.getResponse().getContentAsString(), Property.class);
+        verify(propertyRepository, times(1)).save(property);
+        reset(propertyRepository);
+    }
+
+    @Test
+    public void testUpdatePropertyUnauthoroized() throws Exception{
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.PROPERTY_RESOURCE_URI);
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testUpdateProperty() throws Exception {
+
+        Property property = new Property("property1");
+        property.setOwner("user");
+
+        when(propertyRepository.saveAll(Arrays.asList(argThat(new PropertyMatcher(property)))))
+                .thenReturn(Arrays.asList(property));
+
+        MockHttpServletRequestBuilder request = put("/" +
+                OlogResourceDescriptors.PROPERTY_RESOURCE_URI)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION)
+                .contentType(JSON)
+                .content(objectMapper.writeValueAsString(Arrays.asList(property1)));
+        MvcResult result = mockMvc.perform(request).andExpect(status().isOk()).andReturn();
+        objectMapper.readValue(result.getResponse().getContentAsString(), new TypeReference<Iterable<Property>>() {
+        });
+        verify(propertyRepository, times(1)).saveAll(Arrays.asList(property));
+        reset(propertyRepository);
+    }
+
+    @Test
+    public void testDeleteUnauthorized() throws Exception{
+        MockHttpServletRequestBuilder request = delete("/" +
+                OlogResourceDescriptors.PROPERTY_RESOURCE_URI +
+                "/property1");
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testDelete() throws Exception{
+        MockHttpServletRequestBuilder request = delete("/" +
+                OlogResourceDescriptors.PROPERTY_RESOURCE_URI +
+                "/property1")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION);
+        mockMvc.perform(request).andExpect(status().isOk());
+        verify(propertyRepository, times(1)).deleteById("property1");
+    }
+
+
+
+    /**
+     * A matcher used to work around issues with {@link Property#equals(Object)} when using the mocks.
+     */
+    private class PropertyMatcher implements ArgumentMatcher<Property> {
+        private final Property expected;
+
+        public PropertyMatcher(Property expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        public boolean matches(Property obj) {
+            if (!(obj instanceof Property)) {
+                return false;
+            }
+            Property actual = (Property) obj;
+
+            return actual.getName().equals(expected.getName());
+        }
+    }
+}

--- a/src/test/java/gov/bnl/olog/ResourcesTestBase.java
+++ b/src/test/java/gov/bnl/olog/ResourcesTestBase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 European Spallation Source ERIC.
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.Base64Utils;
+
+public abstract class ResourcesTestBase {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected static final String JSON = "application/json;charset=UTF8";
+
+    protected static final String AUTHORIZATION =
+            "Basic " + Base64Utils.encodeToString("user:userPass".getBytes());
+}

--- a/src/test/java/gov/bnl/olog/ResourcesTestConfig.java
+++ b/src/test/java/gov/bnl/olog/ResourcesTestConfig.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2018 European Spallation Source ERIC.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+package gov.bnl.olog;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.mockito.Mockito;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.gridfs.GridFsOperations;
+import org.springframework.data.mongodb.gridfs.GridFsTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@TestConfiguration
+@EnableWebMvc
+@ComponentScan(basePackages = "gov.bnl.olog")
+@Import({WebSecurityConfig.class})
+@Profile({ "test" })
+public class ResourcesTestConfig {
+
+    @Bean
+    public LogbookRepository logbookRepository(){
+        return Mockito.mock(LogbookRepository.class);
+    }
+
+    @Bean
+    public PropertyRepository propertyRepository(){
+        return Mockito.mock(PropertyRepository.class);
+    }
+
+    @Bean
+    public LogRepository logRepository(){
+        return Mockito.mock(LogRepository.class);
+    }
+
+    @Bean
+    public AttachmentRepository attachmentRepository(){
+        return Mockito.mock(AttachmentRepository.class);
+    }
+
+    @Bean("indexClient")
+    public RestHighLevelClient client(){
+        return Mockito.mock(RestHighLevelClient.class);
+    }
+
+    @Bean
+    public GridFsOperations gridOperation(){
+        return Mockito.mock(GridFsOperations.class);
+    }
+
+    @Bean
+    public GridFsTemplate gridFsTemplate(){
+        return Mockito.mock(GridFsTemplate.class);
+    }
+
+    @Bean
+    public LogSearchUtil logSearchUtil(){
+        return Mockito.mock(LogSearchUtil.class);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper(){
+        return new ObjectMapper();
+    }
+}

--- a/src/test/resources/no_ldap_test_application.properties
+++ b/src/test/resources/no_ldap_test_application.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2020 European Spallation Source ERIC.
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#
+
+ldap.enabled = false
+embedded_ldap.enabled = false
+demo_auth.enabled = true


### PR DESCRIPTION
Using Spring's ability to inject the Principal for each controller method, added this to create methods to set the owner field as defined by the logged in user's credentials.
Decided to not update owner field for update methods, but maybe we should...?

Also added unit tests.